### PR TITLE
scale activations in `DropPath`

### DIFF
--- a/eqxvision/layers/drop_path.py
+++ b/eqxvision/layers/drop_path.py
@@ -50,9 +50,12 @@ class DropPath(eqx.Module):
 
         keep_prob = 1 - self.p
         if self.mode == "global":
-            return x * jrandom.bernoulli(key, p=keep_prob)
+            noise = jrandom.bernoulli(key, p=keep_prob)
         else:
-            return x * jnp.expand_dims(
+            noise = jnp.expand_dims(
                 jrandom.bernoulli(key, p=keep_prob, shape=[x.shape[0]]).reshape(-1),
                 axis=[i for i in range(1, len(x.shape))],
             )
+        if keep_prob > 0.0:
+            noise /= keep_prob
+        return x * noise


### PR DESCRIPTION
Great project! An additional test + a small fix to align `DropPath` with standard dropout and [`torchvision.stochastic_depth`](https://github.com/pytorch/vision/blob/0dceac025615a1c2df6ec1675d8f9d7757432a49/torchvision/ops/stochastic_depth.py#L42-L43).