### PR TITLE
Fix batch norm

### DIFF
--- a/eqxvision/layers/conv_norm_activation.py
+++ b/eqxvision/layers/conv_norm_activation.py
@@ -1,7 +1,6 @@
 from functools import partial
 from typing import Callable, Optional
 
-import equinox.experimental as eqxex
 import equinox.nn as nn
 import jax
 import jax.nn as jnn
@@ -23,7 +22,7 @@ class ConvNormActivation(nn.Sequential):
         stride: int = 1,
         padding: Optional[int] = None,
         groups: int = 1,
-        norm_layer: Optional[Callable] = eqxex.BatchNorm,
+        norm_layer: Optional[Callable] = nn.BatchNorm,
         activation_layer: Optional[Callable] = jnn.relu,
         dilation: int = 1,
         use_bias: Optional[bool] = None,
@@ -72,9 +71,9 @@ class ConvNormActivation(nn.Sequential):
         ]
         if norm_layer is not None:
             is_bn = (
-                norm_layer.func == eqxex.BatchNorm
+                norm_layer.func == nn.BatchNorm
                 if isinstance(norm_layer, partial)
-                else norm_layer == eqxex.BatchNorm
+                else norm_layer == nn.BatchNorm
             )
             if is_bn:
                 layers.append(norm_layer(out_channels, axis_name="batch"))

--- a/eqxvision/layers/conv_norm_activation.py
+++ b/eqxvision/layers/conv_norm_activation.py
@@ -39,7 +39,7 @@ class ConvNormActivation(nn.Sequential):
             in which case it will calculated as ``padding = (kernel_size - 1) // 2 * dilation``
         - `groups`: Number of blocked connections from input channels to output channels. Defaults to `1`
         - `norm_layer`: Norm layer that will be stacked on top of the convolution layer. If ``None``
-            this layer wont be used. Defaults to ``eqx.experimental.BatchNorm``
+            this layer wont be used. Defaults to ``nn.BatchNorm``
         - `activation_layer`: Activation function which will be stacked on top of the normalization layer
             (if not None), otherwise on top of the conv layer
             If ``None`` this layer wont be used. Defaults to ``jax.nn.relu``

--- a/eqxvision/models/classification/densenet.py
+++ b/eqxvision/models/classification/densenet.py
@@ -1,7 +1,6 @@
 from typing import Any, Optional, Sequence, Tuple, Union
 
 import equinox as eqx
-import equinox.experimental as eqxex
 import equinox.nn as nn
 import jax
 import jax.nn as jnn
@@ -13,10 +12,10 @@ from ...utils import load_torch_weights
 
 
 class _DenseLayer(eqx.Module):
-    norm1: eqxex.BatchNorm
+    norm1: nn.BatchNorm
     relu: nn.Lambda
     conv1: nn.Conv2d
-    norm2: eqxex.BatchNorm
+    norm2: nn.BatchNorm
     conv2: nn.Conv2d
     dropout: nn.Dropout
 
@@ -30,7 +29,7 @@ class _DenseLayer(eqx.Module):
     ) -> None:
         super().__init__()
         keys = jrandom.split(key, 2)
-        self.norm1 = eqxex.BatchNorm(num_input_features, axis_name="batch")
+        self.norm1 = nn.BatchNorm(num_input_features, axis_name="batch")
         self.relu = nn.Lambda(jnn.relu)
         self.conv1 = nn.Conv2d(
             num_input_features,
@@ -40,7 +39,7 @@ class _DenseLayer(eqx.Module):
             use_bias=False,
             key=keys[0],
         )
-        self.norm2 = eqxex.BatchNorm(bn_size * growth_rate, axis_name="batch")
+        self.norm2 = nn.BatchNorm(bn_size * growth_rate, axis_name="batch")
         self.conv2 = nn.Conv2d(
             bn_size * growth_rate,
             growth_rate,

--- a/eqxvision/models/classification/densenet.py
+++ b/eqxvision/models/classification/densenet.py
@@ -232,6 +232,7 @@ class DenseNet(eqx.Module):
         """**Arguments:**
 
         - `x`: The input. Should be a JAX array with `3` channels
+        - `state`: The state of the model, necessary for layers such as `BatchNorm`
         - `key`: Required parameter. Utilised by few layers such as `Dropout` or `DropPath`
         """
         out, state = self.features(x, state, key=key)

--- a/eqxvision/models/classification/densenet.py
+++ b/eqxvision/models/classification/densenet.py
@@ -114,7 +114,7 @@ class _Transition(eqx.Module):
         super().__init__()
         self.layers = nn.Sequential(
             [
-                eqxex.BatchNorm(num_input_features, axis_name="batch"),
+                nn.BatchNorm(num_input_features, axis_name="batch"),
                 nn.Lambda(jnn.relu),
                 nn.Conv2d(
                     num_input_features,
@@ -176,7 +176,7 @@ class DenseNet(eqx.Module):
                 use_bias=False,
                 key=keys[0],
             ),
-            eqxex.BatchNorm(num_init_features, axis_name="batch"),
+            nn.BatchNorm(num_init_features, axis_name="batch"),
             nn.Lambda(jnn.relu),
             nn.MaxPool2d(kernel_size=3, stride=2, padding=1),
         ]
@@ -207,7 +207,7 @@ class DenseNet(eqx.Module):
         # Final batch norm, relu and pooling
         features.extend(
             [
-                eqxex.BatchNorm(num_features, axis_name="batch"),
+                nn.BatchNorm(num_features, axis_name="batch"),
                 nn.Lambda(jnn.relu),
                 nn.AdaptiveAvgPool2d((1, 1)),
             ]

--- a/eqxvision/models/classification/densenet.py
+++ b/eqxvision/models/classification/densenet.py
@@ -11,7 +11,7 @@ from jaxtyping import Array
 from ...utils import load_torch_weights
 
 
-class _DenseLayer(eqx.Module):
+class _DenseLayer(nn.StatefulLayer):
     norm1: nn.BatchNorm
     relu: nn.Lambda
     conv1: nn.Conv2d
@@ -67,12 +67,12 @@ class _DenseLayer(eqx.Module):
         x, state = self.norm1(concated_features, state)
         bottleneck_output = self.conv1(self.relu(x))
         x, state = self.norm2(bottleneck_output, state)
-        new_features = self.conv2(self.relu())
+        new_features = self.conv2(self.relu(x))
         new_features = self.dropout(new_features, key=key)
         return new_features, state
 
 
-class _DenseBlock(eqx.Module):
+class _DenseBlock(nn.StatefulLayer):
     layers: Sequence[eqx.Module]
     num_layers: int
 
@@ -110,7 +110,7 @@ class _DenseBlock(eqx.Module):
         return jnp.concatenate(features, 0), state
 
 
-class _Transition(eqx.Module):
+class _Transition(nn.StatefulLayer):
     layers: nn.Sequential
 
     def __init__(

--- a/eqxvision/models/classification/efficientnet.py
+++ b/eqxvision/models/classification/efficientnet.py
@@ -318,7 +318,7 @@ class EfficientNet(eqx.Module):
         keys = jr.split(key, 3)
 
         if norm_layer is None:
-            norm_layer = eqx.experimental.BatchNorm
+            norm_layer = nn.BatchNorm
 
         layers: List[eqx.Module] = []
 
@@ -603,7 +603,7 @@ def efficientnet_b5(torch_weights: str = None, **kwargs: Any) -> EfficientNet:
         0.4,
         last_channel,
         torch_weights,
-        norm_layer=partial(eqx.experimental.BatchNorm, eps=0.001, momentum=0.01),
+        norm_layer=partial(nn.BatchNorm, eps=0.001, momentum=0.01),
         **kwargs,
     )
 
@@ -625,7 +625,7 @@ def efficientnet_b6(torch_weights: str = None, **kwargs: Any) -> EfficientNet:
         0.5,
         last_channel,
         torch_weights,
-        norm_layer=partial(eqx.experimental.BatchNorm, eps=0.001, momentum=0.01),
+        norm_layer=partial(nn.BatchNorm, eps=0.001, momentum=0.01),
         **kwargs,
     )
 
@@ -647,7 +647,7 @@ def efficientnet_b7(torch_weights: str = None, **kwargs: Any) -> EfficientNet:
         0.5,
         last_channel,
         torch_weights,
-        norm_layer=partial(eqx.experimental.BatchNorm, eps=0.001, momentum=0.01),
+        norm_layer=partial(nn.BatchNorm, eps=0.001, momentum=0.01),
         **kwargs,
     )
 
@@ -668,7 +668,7 @@ def efficientnet_v2_s(torch_weights: str = None, **kwargs: Any) -> EfficientNet:
         0.2,
         last_channel,
         torch_weights,
-        norm_layer=partial(eqx.experimental.BatchNorm, eps=1e-03),
+        norm_layer=partial(nn.BatchNorm, eps=1e-03),
         **kwargs,
     )
 
@@ -689,7 +689,7 @@ def efficientnet_v2_m(torch_weights: str = None, **kwargs: Any) -> EfficientNet:
         0.3,
         last_channel,
         torch_weights,
-        norm_layer=partial(eqx.experimental.BatchNorm, eps=1e-03),
+        norm_layer=partial(nn.BatchNorm, eps=1e-03),
         **kwargs,
     )
 
@@ -710,6 +710,6 @@ def efficientnet_v2_l(torch_weights: str = None, **kwargs: Any) -> EfficientNet:
         0.4,
         last_channel,
         torch_weights,
-        norm_layer=partial(eqx.experimental.BatchNorm, eps=1e-03),
+        norm_layer=partial(nn.BatchNorm, eps=1e-03),
         **kwargs,
     )

--- a/eqxvision/models/classification/efficientnet.py
+++ b/eqxvision/models/classification/efficientnet.py
@@ -92,7 +92,7 @@ class _FusedMBConvConfig(_MBConvConfigData):
         )
 
 
-class _MBConv(eqx.Module):
+class _MBConv(nn.StatefulLayer):
     use_res_connect: bool
     block: nn.Sequential
     stochastic_depth: DropPath
@@ -188,7 +188,7 @@ class _MBConv(eqx.Module):
         return result, state
 
 
-class _FusedMBConv(eqx.Module):
+class _FusedMBConv(nn.StatefulLayer):
     use_res_connect: bool
     block: nn.Sequential
     stochastic_depth: DropPath
@@ -399,6 +399,7 @@ class EfficientNet(eqx.Module):
         """**Arguments:**
 
         - `x`: The input `JAX` array.
+        - `state`: The state of the model, necessary for layers such as `BatchNorm`
         - `key`: Required parameter. Utilised by few layers such as `Dropout` or `DropPath`.
         """
         keys = jr.split(key, 2)

--- a/eqxvision/models/classification/googlenet.py
+++ b/eqxvision/models/classification/googlenet.py
@@ -286,7 +286,7 @@ class InceptionAux(eqx.Module):
 
 class BasicConv2d(eqx.Module):
     conv: nn.Conv2d
-    bn: eqx.experimental.BatchNorm
+    bn: nn.BatchNorm
 
     def __init__(
         self,
@@ -300,7 +300,7 @@ class BasicConv2d(eqx.Module):
         self.conv = nn.Conv2d(
             in_channels, out_channels, use_bias=False, key=key, **kwargs
         )
-        self.bn = eqx.experimental.BatchNorm(out_channels, axis_name="batch", eps=0.001)
+        self.bn = nn.BatchNorm(out_channels, axis_name="batch", eps=0.001)
 
     def __call__(
         self, x: Array, *, key: Optional["jax.random.PRNGKey"] = None

--- a/eqxvision/models/classification/googlenet.py
+++ b/eqxvision/models/classification/googlenet.py
@@ -115,8 +115,8 @@ class GoogLeNet(eqx.Module):
         self.fc = nn.Linear(1024, num_classes, key=keys[14])
 
     def __call__(
-        self, x: Array, *, key: "jax.random.PRNGKey"
-    ) -> Union[Array, Optional[Array], Optional[Array]]:
+        self, x: Array, state: nn.State, *, key: "jax.random.PRNGKey"
+    ) -> Tuple[Union[Array, Optional[Array], Optional[Array]], nn.State]:
         """**Arguments:**
 
         - `x`: The input. Should be a JAX array with `3` channels
@@ -126,44 +126,44 @@ class GoogLeNet(eqx.Module):
             raise RuntimeError("The model requires a PRNGKey.")
         keys = jrandom.split(key, 14)
         # N x 3 x 224 x 224
-        x = self.conv1(x, key=keys[0])
+        x, state = self.conv1(x, state, key=keys[0])
         # N x 64 x 112 x 112
         x = self.maxpool1(x, key=keys[1])
         # N x 64 x 56 x 56
-        x = self.conv2(x, key=keys[2])
+        x, state = self.conv2(x, state, key=keys[2])
         # N x 64 x 56 x 56
-        x = self.conv3(x, key=keys[3])
+        x, state = self.conv3(x, state, key=keys[3])
         # N x 192 x 56 x 56
         x = self.maxpool2(x)
 
         # N x 192 x 28 x 28
-        x = self.inception3a(x, key=keys[4])
+        x, state = self.inception3a(x, state, key=keys[4])
         # N x 256 x 28 x 28
-        x = self.inception3b(x, key=keys[5])
+        x, state = self.inception3b(x, state, key=keys[5])
         # N x 480 x 28 x 28
         x = self.maxpool3(x)
         # N x 480 x 14 x 14
-        x = self.inception4a(x, key=keys[6])
+        x, state = self.inception4a(x, state, key=keys[6])
         # N x 512 x 14 x 14
         if self.aux_logits:
-            aux1 = self.aux1(x, key=keys[7])
+            aux1, state = self.aux1(x, state, key=keys[7])
 
-        x = self.inception4b(x, key=keys[8])
+        x, state = self.inception4b(x, state, key=keys[8])
         # N x 512 x 14 x 14
-        x = self.inception4c(x, key=keys[9])
+        x, state = self.inception4c(x, state, key=keys[9])
         # N x 512 x 14 x 14
-        x = self.inception4d(x, key=keys[10])
+        x, state = self.inception4d(x, state, key=keys[10])
         # N x 528 x 14 x 14
         if self.aux_logits:
-            aux2 = self.aux2(x, key=keys[11])  # Key here, a bad thing?
+            aux2, state = self.aux2(x, state, key=keys[11])  # Key here, a bad thing?
 
-        x = self.inception4e(x, key=keys[12])
+        x, state = self.inception4e(x, state, key=keys[12])
         # N x 832 x 14 x 14
         x = self.maxpool4(x)
         # N x 832 x 7 x 7
-        x = self.inception5a(x, key=keys[13])
+        x, state = self.inception5a(x, state, key=keys[13])
         # N x 832 x 7 x 7
-        x = self.inception5b(x, key=keys[14])
+        x, state = self.inception5b(x, state, key=keys[14])
         # N x 1024 x 7 x 7
 
         x = self.avgpool(x)
@@ -174,12 +174,12 @@ class GoogLeNet(eqx.Module):
         x = self.fc(x)
         # N x 1000 (num_classes)
         if self.aux_logits:
-            return x, aux2, aux1
+            return x, aux2, aux1, state
         else:
-            return x
+            return x, state
 
 
-class _Inception(eqx.Module):
+class _Inception(nn.StatefulLayer):
     branch1: eqx.Module
     branch2: nn.Sequential
     branch3: nn.Sequential
@@ -226,19 +226,21 @@ class _Inception(eqx.Module):
             ]
         )
 
-    def __call__(self, x: Array, *, key: jax.random.PRNGKey = None) -> Array:
+    def __call__(
+        self, x: Array, state: nn.State, *, key: jax.random.PRNGKey = None
+    ) -> Tuple[Array, nn.State]:
         keys = jrandom.split(key, 4)
-        branch1 = self.branch1(x, key=keys[0])
-        branch2 = self.branch2(x, key=keys[1])
-        branch3 = self.branch3(x, key=keys[2])
-        branch4 = self.branch4(x, key=keys[3])
+        branch1, state = self.branch1(x, state, key=keys[0])
+        branch2, state = self.branch2(x, state, key=keys[1])
+        branch3, state = self.branch3(x, state, key=keys[2])
+        branch4, state = self.branch4(x, state, key=keys[3])
 
         outputs = jnp.concatenate([branch1, branch2, branch3, branch4], axis=0)
-        return outputs
+        return outputs, state
 
 
-class InceptionAux(eqx.Module):
-    conv: eqx.Module
+class InceptionAux(nn.StatefulLayer):
+    conv: nn.StatefulLayer
     fc1: nn.Linear
     fc2: nn.Linear
     dropout: nn.Dropout
@@ -265,12 +267,14 @@ class InceptionAux(eqx.Module):
             (4, 4),
         )
 
-    def __call__(self, x: Array, *, key: "jax.random.PRNGKey" = None) -> Array:
+    def __call__(
+        self, x: Array, state: nn.State, *, key: "jax.random.PRNGKey" = None
+    ) -> Tuple[Array, nn.State]:
         keys = jrandom.split(key, 2)
         # aux1: N x 512 x 14 x 14, aux2: N x 528 x 14 x 14
         x = self.avgpool(x)
         # aux1: N x 512 x 4 x 4, aux2: N x 528 x 4 x 4
-        x = self.conv(x, key=keys[0])
+        x, state = self.conv(x, state, key=keys[0])
         # N x 128 x 4 x 4
         x = jnp.ravel(x)
         # N x 2048
@@ -281,10 +285,10 @@ class InceptionAux(eqx.Module):
         x = self.fc2(x)
         # N x 1000 (num_classes)
 
-        return x
+        return x, state
 
 
-class BasicConv2d(eqx.Module):
+class BasicConv2d(nn.StatefulLayer):
     conv: nn.Conv2d
     bn: nn.BatchNorm
 

--- a/eqxvision/models/classification/mobilenetv2.py
+++ b/eqxvision/models/classification/mobilenetv2.py
@@ -99,7 +99,7 @@ class MobileNetV2(eqx.Module):
         width_mult: float = 1.0,
         inverted_residual_setting: Optional[List[List[int]]] = None,
         round_nearest: int = 8,
-        block: Optional["eqx.Module"] = None,Update
+        block: Optional["eqx.Module"] = None,
         norm_layer: Optional["eqx.Module"] = None,
         dropout: float = 0.2,
         *,

--- a/eqxvision/models/classification/mobilenetv2.py
+++ b/eqxvision/models/classification/mobilenetv2.py
@@ -1,7 +1,6 @@
 from typing import Any, Callable, List, Optional
 
 import equinox as eqx
-import equinox.experimental as eqxex
 import equinox.nn as nn
 import jax
 import jax.nn as jnn
@@ -37,7 +36,7 @@ class _InvertedResidual(eqx.Module):
         assert stride in [1, 2]
 
         if norm_layer is None:
-            norm_layer = eqxex.BatchNorm
+            norm_layer = nn.BatchNorm
 
         hidden_dim = int(round(inp * expand_ratio))
         self.use_res_connect = self.stride == 1 and inp == oup
@@ -100,7 +99,7 @@ class MobileNetV2(eqx.Module):
         width_mult: float = 1.0,
         inverted_residual_setting: Optional[List[List[int]]] = None,
         round_nearest: int = 8,
-        block: Optional["eqx.Module"] = None,
+        block: Optional["eqx.Module"] = None,Update
         norm_layer: Optional["eqx.Module"] = None,
         dropout: float = 0.2,
         *,
@@ -131,7 +130,7 @@ class MobileNetV2(eqx.Module):
             block = _InvertedResidual
 
         if norm_layer is None:
-            norm_layer = eqxex.BatchNorm
+            norm_layer = nn.BatchNorm
 
         input_channel = 32
         last_channel = 1280

--- a/eqxvision/models/classification/mobilenetv3.py
+++ b/eqxvision/models/classification/mobilenetv3.py
@@ -2,7 +2,6 @@ from functools import partial
 from typing import Any, Callable, List, Optional, Sequence
 
 import equinox as eqx
-import equinox.experimental as eqxex
 import equinox.nn as nn
 import jax
 import jax.nn as jnn
@@ -186,7 +185,7 @@ class MobileNetV3(eqx.Module):
             block = _InvertedResidual
 
         if norm_layer is None:
-            norm_layer = partial(eqxex.BatchNorm, eps=0.001, momentum=0.01)
+            norm_layer = partial(nn.BatchNorm, eps=0.001, momentum=0.01)
 
         layers: List[eqx.Module] = []
 

--- a/eqxvision/models/classification/mobilenetv3.py
+++ b/eqxvision/models/classification/mobilenetv3.py
@@ -42,7 +42,7 @@ class _InvertedResidualConfig:
         return _make_divisible(channels * width_mult, 8)
 
 
-class _InvertedResidual(eqx.Module):
+class _InvertedResidual(nn.StatefulLayer):
     # Implemented as described at section 5 of MobileNetV3 paper
     use_res_connect: int
     block: nn.Sequential

--- a/eqxvision/models/classification/regnet.py
+++ b/eqxvision/models/classification/regnet.py
@@ -365,7 +365,7 @@ class RegNet(eqx.Module):
         if stem_type is None:
             stem_type = SimpleStemIN
         if norm_layer is None:
-            norm_layer = eqx.experimental.BatchNorm
+            norm_layer = nn.BatchNorm
         if block_type is None:
             block_type = ResBottleneckBlock
         if activation is None:
@@ -438,7 +438,7 @@ def _regnet(
 ) -> RegNet:
 
     norm_layer = kwargs.pop(
-        "norm_layer", partial(eqx.experimental.BatchNorm, eps=1e-05, momentum=0.1)
+        "norm_layer", partial(nn.BatchNorm, eps=1e-05, momentum=0.1)
     )
     model = RegNet(block_params, norm_layer=norm_layer, **kwargs)
     if torch_weights:

--- a/eqxvision/models/classification/resnet.py
+++ b/eqxvision/models/classification/resnet.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, List, Optional, Sequence, Type, Union
 
 import equinox as eqx
-import equinox.experimental as eqex
+import equinox.experimental as nn
 import equinox.nn as nn
 import jax
 import jax.nn as jnn
@@ -58,7 +58,7 @@ class _ResNetBasicBlock(eqx.Module):
     ):
         super(_ResNetBasicBlock, self).__init__()
         if norm_layer is None:
-            norm_layer = eqex.BatchNorm
+            norm_layer = nn.BatchNorm
         if groups != 1 or base_width != 64:
             raise ValueError("BasicBlock only supports groups=1 and base_width=64")
         if dilation > 1:
@@ -123,7 +123,7 @@ class _ResNetBottleneck(eqx.Module):
     ):
         super(_ResNetBottleneck, self).__init__()
         if norm_layer is None:
-            norm_layer = eqex.BatchNorm
+            norm_layer = nn.BatchNorm
         self.expansion = 4
         keys = jrandom.split(key, 3)
         width = int(planes * (base_width / 64.0)) * groups
@@ -217,9 +217,9 @@ class ResNet(eqx.Module):
         """
         super(ResNet, self).__init__()
         if not norm_layer:
-            norm_layer = eqex.BatchNorm
+            norm_layer = nn.BatchNorm
 
-        if eqex.BatchNorm != norm_layer:
+        if nn.BatchNorm != norm_layer:
             raise NotImplementedError(
                 f"{type(norm_layer)} is not currently supported. Use `eqx.experimental.BatchNorm` instead."
             )

--- a/eqxvision/models/classification/resnet.py
+++ b/eqxvision/models/classification/resnet.py
@@ -333,30 +333,26 @@ class ResNet(eqx.Module):
         return nn.Sequential(layers)
 
     def __call__(
-        self, x: Array, state: nn.State, *, key: "jax.random.PRNGKey"
+        self, x: Array, state: nn.State, *, key: Optional["jax.random.PRNGKey"] = None
     ) -> Tuple[Array, nn.State]:
         """**Arguments:**
 
         - `x`: The input. Should be a JAX array with `3` channels
         - `state`: The state of the model, necessary for batch norm
-        - `key`: Required parameter. Utilised by few layers such as `Dropout` or `DropPath`
         """
-        if key is None:
-            raise RuntimeError("The model requires a PRNGKey.")
-        keys = jrandom.split(key, 6)
-        x = self.conv1(x, key=keys[0])
+        x = self.conv1(x)
         x, state = self.bn1(x, state)
         x = self.relu(x)
         x = self.maxpool(x)
 
-        x, state = self.layer1(x, state, key=keys[1])
-        x, state = self.layer2(x, state, key=keys[2])
-        x, state = self.layer3(x, state, key=keys[3])
-        x, state = self.layer4(x, state, key=keys[4])
+        x, state = self.layer1(x, state)
+        x, state = self.layer2(x, state)
+        x, state = self.layer3(x, state)
+        x, state = self.layer4(x, state)
 
         x = self.avgpool(x)
         x = jnp.ravel(x)
-        x = self.fc(x, key=keys[5])
+        x = self.fc(x)
 
         return x, state
 

--- a/eqxvision/models/classification/resnet.py
+++ b/eqxvision/models/classification/resnet.py
@@ -1,7 +1,6 @@
 from typing import Any, Callable, List, Optional, Sequence, Type, Union
 
 import equinox as eqx
-import equinox.experimental as nn
 import equinox.nn as nn
 import jax
 import jax.nn as jnn
@@ -142,7 +141,6 @@ class _ResNetBottleneck(eqx.Module):
         self.stride = stride
 
     def __call__(self, x: Array, *, key: Optional["jax.random.PRNGKey"] = None):
-
         out = self.conv1(x)
         out = self.bn1(out)
         out = self.relu(out)
@@ -221,7 +219,7 @@ class ResNet(eqx.Module):
 
         if nn.BatchNorm != norm_layer:
             raise NotImplementedError(
-                f"{type(norm_layer)} is not currently supported. Use `eqx.experimental.BatchNorm` instead."
+                f"{type(norm_layer)} is not currently supported. Use `nn.BatchNorm` instead."
             )
         if key is None:
             key = jrandom.PRNGKey(0)

--- a/eqxvision/models/classification/shufflenetv2.py
+++ b/eqxvision/models/classification/shufflenetv2.py
@@ -1,7 +1,6 @@
 from typing import Any, List, Optional
 
 import equinox as eqx
-import equinox.experimental as eqxex
 import equinox.nn as nn
 import jax
 import jax.nn as jnn
@@ -56,7 +55,7 @@ class _InvertedResidual(eqx.Module):
                         padding=1,
                         key=keys[0],
                     ),
-                    eqxex.BatchNorm(inp, axis_name="batch"),
+                    nn.BatchNorm(inp, axis_name="batch"),
                     nn.Conv2d(
                         inp,
                         branch_features,
@@ -66,7 +65,7 @@ class _InvertedResidual(eqx.Module):
                         use_bias=False,
                         key=keys[1],
                     ),
-                    eqxex.BatchNorm(branch_features, axis_name="batch"),
+                    nn.BatchNorm(branch_features, axis_name="batch"),
                     nn.Lambda(jnn.relu),
                 ]
             )
@@ -84,7 +83,7 @@ class _InvertedResidual(eqx.Module):
                     use_bias=False,
                     key=keys[2],
                 ),
-                eqxex.BatchNorm(branch_features, axis_name="batch"),
+                nn.BatchNorm(branch_features, axis_name="batch"),
                 nn.Lambda(jnn.relu),
                 self.depthwise_conv(
                     branch_features,
@@ -94,7 +93,7 @@ class _InvertedResidual(eqx.Module):
                     padding=1,
                     key=keys[3],
                 ),
-                eqxex.BatchNorm(branch_features, axis_name="batch"),
+                nn.BatchNorm(branch_features, axis_name="batch"),
                 nn.Conv2d(
                     branch_features,
                     branch_features,
@@ -104,7 +103,7 @@ class _InvertedResidual(eqx.Module):
                     use_bias=False,
                     key=keys[4],
                 ),
-                eqxex.BatchNorm(branch_features, axis_name="batch"),
+                nn.BatchNorm(branch_features, axis_name="batch"),
                 nn.Lambda(jnn.relu),
             ]
         )
@@ -188,7 +187,7 @@ class ShuffleNetV2(eqx.Module):
                     use_bias=False,
                     key=keys[0],
                 ),
-                eqxex.BatchNorm(output_channels, axis_name="batch"),
+                nn.BatchNorm(output_channels, axis_name="batch"),
                 nn.Lambda(jnn.relu),
             ]
         )
@@ -227,7 +226,7 @@ class ShuffleNetV2(eqx.Module):
                     use_bias=False,
                     key=keys[0],
                 ),
-                eqxex.BatchNorm(output_channels, axis_name="batch"),
+                nn.BatchNorm(output_channels, axis_name="batch"),
                 nn.Lambda(jnn.relu),
             ]
         )

--- a/eqxvision/models/classification/vgg.py
+++ b/eqxvision/models/classification/vgg.py
@@ -1,7 +1,7 @@
 from typing import Any, cast, Dict, List, Optional, Union
 
 import equinox as eqx
-import equinox.experimental as eqex
+import equinox.experimental as nn
 import equinox.nn as nn
 import jax
 import jax.nn as jnn
@@ -140,7 +140,7 @@ def _make_layers(
             if batch_norm:
                 layers += [
                     conv2d,
-                    eqex.BatchNorm(v, axis_name="batch"),
+                    nn.BatchNorm(v, axis_name="batch"),
                     nn.Lambda(jnn.relu),
                 ]
             else:

--- a/eqxvision/models/classification/vgg.py
+++ b/eqxvision/models/classification/vgg.py
@@ -1,7 +1,6 @@
-from typing import Any, cast, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, cast
 
 import equinox as eqx
-import equinox.experimental as nn
 import equinox.nn as nn
 import jax
 import jax.nn as jnn
@@ -10,7 +9,6 @@ import jax.random as jrandom
 from jaxtyping import Array
 
 from ...utils import load_torch_weights
-
 
 _cfgs: Dict[str, List[Union[str, int]]] = {
     "A": [64, "M", 128, "M", 256, 256, "M", 512, 512, "M", 512, 512, "M"],
@@ -124,7 +122,6 @@ def _make_layers(
     batch_norm: bool = False,
     key: "jax.random.PRNGKey" = None,
 ) -> nn.Sequential:
-
     layers: List[eqx.Module] = []
     in_channels = 3
     keys = jrandom.split(key=key, num=len(cfg) - cfg.count("M"))

--- a/eqxvision/models/classification/vgg.py
+++ b/eqxvision/models/classification/vgg.py
@@ -1,4 +1,4 @@
-from typing import Any, cast, Dict, List, Optional, Union
+from typing import Any, cast, Dict, List, Optional, Tuple, Union
 
 import equinox as eqx
 import equinox.nn as nn
@@ -74,7 +74,7 @@ class VGG(eqx.Module):
         batch_norm: bool = True,
         dropout: float = 0.5,
         *,
-        key: Optional["jax.random.PRNGKey"] = None
+        key: Optional["jax.random.PRNGKey"] = None,
     ) -> None:
         """**Arguments:**
 
@@ -104,18 +104,21 @@ class VGG(eqx.Module):
             ]
         )
 
-    def __call__(self, x: Array, *, key: "jax.random.PRNGKey") -> Array:
+    def __call__(
+        self, x: Array, state: nn.State, *, key: "jax.random.PRNGKey"
+    ) -> Tuple[Array, nn.State]:
         """**Arguments:**
 
         - `x`: The input. Should be a JAX array with `3` channels.
+        - `state`: The state of the model, necessary for layers such as `BatchNorm`.
         - `key`: Required parameter. Utilised by few layers such as `Dropout` or `DropPath`.
         """
         keys = jrandom.split(key, 2)
-        x = self.features(x, key=keys[0])
+        x, state = self.features(x, state, key=keys[0])
         x = self.avgpool(x)
         x = jnp.ravel(x)
         x = self.classifier(x, key=keys[1])
-        return x
+        return x, state
 
 
 def _make_layers(

--- a/eqxvision/models/classification/vgg.py
+++ b/eqxvision/models/classification/vgg.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, cast, Dict, List, Optional, Union
 
 import equinox as eqx
 import equinox.nn as nn
@@ -9,6 +9,7 @@ import jax.random as jrandom
 from jaxtyping import Array
 
 from ...utils import load_torch_weights
+
 
 _cfgs: Dict[str, List[Union[str, int]]] = {
     "A": [64, "M", 128, "M", 256, 256, "M", 512, 512, "M", 512, 512, "M"],

--- a/eqxvision/models/segmentation/deeplabv3.py
+++ b/eqxvision/models/segmentation/deeplabv3.py
@@ -28,7 +28,7 @@ class DeepLabHead(nn.Sequential):
             [
                 ASPP(in_channels, [12, 24, 36], key=keys[0]),
                 nn.Conv2d(256, 256, 3, padding=1, use_bias=False, key=keys[1]),
-                eqx.experimental.BatchNorm(256, axis_name="batch"),
+                nn.BatchNorm(256, axis_name="batch"),
                 nn.Lambda(jnn.relu),
                 nn.Conv2d(256, out_channels, 1, key=keys[2]),
             ]
@@ -49,7 +49,7 @@ class ASPPConv(nn.Sequential):
                 use_bias=False,
                 key=key,
             ),
-            eqx.experimental.BatchNorm(out_channels, axis_name="batch"),
+            nn.BatchNorm(out_channels, axis_name="batch"),
             nn.Lambda(jnn.relu),
         ]
         super().__init__(modules)
@@ -61,7 +61,7 @@ class ASPPPooling(nn.Sequential):
             [
                 nn.AdaptiveAvgPool2d(1),
                 nn.Conv2d(in_channels, out_channels, 1, use_bias=False, key=key),
-                eqx.experimental.BatchNorm(out_channels, axis_name="batch"),
+                nn.BatchNorm(out_channels, axis_name="batch"),
                 nn.Lambda(jnn.relu),
             ]
         )
@@ -97,7 +97,7 @@ class ASPP(eqx.Module):
                     nn.Conv2d(
                         in_channels, out_channels, 1, use_bias=False, key=keys[0]
                     ),
-                    eqx.experimental.BatchNorm(out_channels, axis_name="batch"),
+                    nn.BatchNorm(out_channels, axis_name="batch"),
                     nn.Lambda(jnn.relu),
                 ]
             )
@@ -119,7 +119,7 @@ class ASPP(eqx.Module):
                     use_bias=False,
                     key=keys[-1],
                 ),
-                eqx.experimental.BatchNorm(out_channels, axis_name="batch"),
+                nn.BatchNorm(out_channels, axis_name="batch"),
                 nn.Lambda(jnn.relu),
                 nn.Dropout(0.5),
             ]

--- a/eqxvision/models/segmentation/fcn.py
+++ b/eqxvision/models/segmentation/fcn.py
@@ -26,7 +26,7 @@ class FCNHead(nn.Sequential):
             nn.Conv2d(
                 in_channels, inter_channels, 3, padding=1, use_bias=False, key=keys[0]
             ),
-            eqx.experimental.BatchNorm(inter_channels, axis_name="batch"),
+            nn.BatchNorm(inter_channels, axis_name="batch"),
             nn.Lambda(jnn.relu),
             nn.Dropout(0.1),
             nn.Conv2d(inter_channels, out_channels, 1, key=keys[1]),

--- a/eqxvision/models/segmentation/lraspp.py
+++ b/eqxvision/models/segmentation/lraspp.py
@@ -89,7 +89,7 @@ class LRASPPHead(eqx.Module):
                 nn.Conv2d(
                     high_channels, inter_channels, 1, use_bias=False, key=keys[0]
                 ),
-                eqx.experimental.BatchNorm(inter_channels, axis_name="batch"),
+                nn.BatchNorm(inter_channels, axis_name="batch"),
                 nn.Lambda(jnn.relu),
             ]
         )


### PR DESCRIPTION
Trying to revive PR #71 and solve issue #70. These changes should complete the refactor and use the new `state` mechanic.
However, currently this causes the following error in the `Sequential` module:
```
File "/home/user/eqxvision/eqx_train.py", line 296, in forward
    pred_ys, state = batch_model(images, state, key=keys)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/miniconda3/envs/equinox/lib/python3.11/site-packages/eqxvision/models/classification/resnet.py", line 352, in __call__
    x, state = self.layer1(x, state, key=keys[1])
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/miniconda3/envs/equinox/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/user/miniconda3/envs/equinox/lib/python3.11/site-packages/equinox/nn/_sequential.py", line 68, in __call__
    x = layer(x, key=key)
        ^^^^^^^^^^^^^^^^^
TypeError: _ResNetBasicBlock.__call__() missing 1 required positional argument: 'state'
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.
```

Can be reproduced with:
```python
import jax
import equinox as eqx
from eqxvision.models import resnet18

@eqx.filter_jit
def forward(model, state, images):
    keys = jax.random.split(jax.random.PRNGKey(0), images.shape[0])
    batch_model = jax.vmap(
        model, axis_name="batch", in_axes=(0, None), out_axes=(0, None)
    )
    pred_ys, state = batch_model(images, state, key=keys)
    return pred_ys


net = resnet18()
state = eqx.nn.State(net)

images = jax.random.uniform(jax.random.PRNGKey(0), shape=(1, 3, 64, 64))
output = forward(net, state, images)
```

@patrick-kidger Any idea how to solve this? Should we get rid of the if-else statement causing this error that checks for `isinstance(layer, StatefulLayer)` in `_sequential`?